### PR TITLE
Improve print layout lines

### DIFF
--- a/script.js
+++ b/script.js
@@ -175,16 +175,18 @@
                         padding: ${lineHeight}; /* Padding around the page, equal to one line */
                         margin: 0;
 
-                        /* Lined paper effect */
+                        /* Crucial for printing background graphics */
+                        -webkit-print-color-adjust: exact !important;
+                        print-color-adjust: exact !important;
+                    }
+
+                    .lined-content {
                         background-color: #fdfdfa; /* Slightly off-white paper color */
                         background-image: linear-gradient(to bottom, transparent 0%, transparent calc(${lineHeight} - 1px), ${lineColor} calc(${lineHeight} - 1px), ${lineColor} ${lineHeight});
                         background-size: 100% ${lineHeight};
                         background-position: 0 0; /* Start lines from top-left of padding box */
                         background-repeat: repeat-y;
-
-                        /* Crucial for printing background graphics */
-                        -webkit-print-color-adjust: exact !important;
-                        print-color-adjust: exact !important;
+                        min-height: calc(100vh - var(--content-offset, 0px));
                     }
 
                     /* Ensure common text elements inherit line-height and have transparent backgrounds */
@@ -247,6 +249,16 @@
         `);
         printWindow.document.close();
         setTimeout(() => {
+            const pageHeight = Math.max(printWindow.innerHeight, printWindow.document.documentElement.clientHeight);
+            const blocks = printWindow.document.querySelectorAll('.sub-assignment-block');
+            blocks.forEach(block => {
+                const lined = block.querySelector('.lined-content');
+                if (lined) {
+                    const rect = lined.getBoundingClientRect();
+                    const offset = rect.top % pageHeight;
+                    lined.style.setProperty('--content-offset', offset + 'px');
+                }
+            });
             printWindow.focus();
             printWindow.print();
         }, 500);
@@ -305,7 +317,7 @@
                 if (questionsHtml) {
                     allContent += questionsHtml;
                 }
-                allContent += `<div>${content}</div>`; // This div wraps the Quill content
+                allContent += `<div class="lined-content">${content}</div>`; // Wrapped in lined content for background lines
                 allContent += `</div>`;
                 if (index < storageKeys.length - 1) {
                     allContent += `<hr>`;


### PR DESCRIPTION
## Summary
- add min-height to `.lined-content` so lined background fills the remaining page
- compute offset for each page and apply as CSS variable before printing

## Testing
- `true`